### PR TITLE
FHIR-41544 RelatedPerson updates, and FHIR-41466 DeviceNotRequested must supports

### DIFF
--- a/input/profiles/StructureDefinition-qicore-devicenotrequested.json
+++ b/input/profiles/StructureDefinition-qicore-devicenotrequested.json
@@ -192,28 +192,10 @@
         "mustSupport" : true
       },
       {
-        "id" : "DeviceRequest.encounter",
-        "path" : "DeviceRequest.encounter",
-        "type" : [
-          {
-            "code" : "Reference",
-            "targetProfile" : [
-              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"
-            ]
-          }
-        ],
-        "mustSupport" : true
-      },
-      {
         "id" : "DeviceRequest.authoredOn",
         "path" : "DeviceRequest.authoredOn",
         "min" : 1,
         "max" : "1",
-        "mustSupport" : true
-      },
-      {
-        "id" : "DeviceRequest.note",
-        "path" : "DeviceRequest.note",
         "mustSupport" : true
       }
     ]

--- a/input/profiles/StructureDefinition-qicore-relatedperson.json
+++ b/input/profiles/StructureDefinition-qicore-relatedperson.json
@@ -51,23 +51,92 @@
       "mustSupport" : false
     },
     {
-      "id" : "RelatedPerson.patient",
-      "path" : "RelatedPerson.patient",
-      "type" : [{
-        "code" : "Reference",
-        "targetProfile" : ["http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"]
-      }],
-      "mustSupport" : true
+        "id" : "RelatedPerson.active",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.active",
+        "short" : "(USCDI) Whether this related person's record is in active use",
+        "min" : 1,
+        "mustSupport" : true
     },
     {
-      "id" : "RelatedPerson.gender",
-      "path" : "RelatedPerson.gender",
-      "mustSupport" : true
-    },
-    {
-      "id" : "RelatedPerson.period",
-      "path" : "RelatedPerson.period",
-      "mustSupport" : true
-    }]
+        "id" : "RelatedPerson.patient",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.patient",
+        "short" : "The patient this person is related to",
+        "type" : [
+          {
+            "code" : "Reference",
+            "targetProfile" : [
+              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"
+            ]
+          }
+        ],
+        "mustSupport" : true
+      },
+      {
+        "id" : "RelatedPerson.relationship",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.relationship",
+        "short" : "(USCDI) The nature of the relationship",
+        "condition" : [
+          "us-core-14"
+        ],
+        "mustSupport" : true
+      },
+      {
+        "id" : "RelatedPerson.name",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.name",
+        "short" : "(USCDI) A name associated with the person",
+        "condition" : [
+          "us-core-14"
+        ],
+        "mustSupport" : true
+      },
+      {
+        "id" : "RelatedPerson.telecom",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.telecom",
+        "short" : "(USCDI) A contact detail for the person",
+        "mustSupport" : true
+      },
+      {
+        "id" : "RelatedPerson.address",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/uscdi-requirement",
+            "valueBoolean" : true
+          }
+        ],
+        "path" : "RelatedPerson.address",
+        "short" : "(USCDI) Address where the related person can be contacted or visited",
+        "mustSupport" : true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Imported differential elements from US Core RelatedPerson 6.1.0 into QI Core differential elements.
Removed  .gender and .period differential elements from QI Core differential elements.

See:  https://jira.hl7.org/browse/FHIR-41544