### PR TITLE
FHIR-42411 - Applied changes to qdm-to-qicore

### DIFF
--- a/input/pages/qdm-to-qicore.md
+++ b/input/pages/qdm-to-qicore.md
@@ -1984,7 +1984,7 @@ Medication mappings listed in this QDM-to-QI-Core section.
 FHIR defines substance as a homogeneous material with a definite
 composition. Medications are classified as substances. However, to
 reference other substances, especially using the
-[SubstanceDefinition](http://hl7.org/fhir/substancespecification.html#SubstanceSpecification)
+[SubstanceDefinition](https://www.hl7.org/fhir/substancedefinition.html)
 resource is challenging since the resource is still undergoing
 development.
 


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-42411

NOTE: http://hl7.org/fhir/extensibility-registry.html is broken because it's no longer there. HL7 needs to restore it or provide the new url. (Googling 'hl7 ghir extensibility registry' brings up a broken link as well as the second result.) Space between Result and that already included under Intervention, Performed.