### PR TITLE
FHIR-46659

### DIFF
--- a/input/profiles/StructureDefinition-qicore-task.json
+++ b/input/profiles/StructureDefinition-qicore-task.json
@@ -66,7 +66,7 @@
           }
         ],
         "path" : "Task.identifier",
-        "short" : "(QI-Core) Task Instance Identifier",
+        "short" : "(QI) Task Instance Identifier",
         "min" : 1,
         "max" : "*"
       },
@@ -90,7 +90,7 @@
           }
         ],
         "path" : "Task.status",
-        "short" : "(QI-Core) draft​ | requested​ | received​ | accepted​ | ready​ | cancelled​ | in-progress​ | on-hold​ | failed​ | completed | entered-in-error",
+        "short" : "(QI) draft​ | requested​ | received​ | accepted​ | ready​ | cancelled​ | in-progress​ | on-hold​ | failed​ | completed | entered-in-error",
         "min" : 1,
         "max" : "1",
         "binding": {
@@ -107,7 +107,7 @@
           }
         ],
         "path" : "Task.intent",
-        "short" : "(QI-Core) unknown | proposal | plan | order | original-order | reflex-order | filler-order | instance",
+        "short" : "(QI) unknown | proposal | plan | order | original-order | reflex-order | filler-order | instance",
         "min" : 1,
         "max" : "1"
       },
@@ -120,7 +120,7 @@
           }
         ],
         "path" : "Task.priority",
-        "short" : "(QI-Core) routine | urgent | asap | stat",
+        "short" : "(QI) routine | urgent | asap | stat",
         "min" : 1,
         "max" : "1"
       },
@@ -133,7 +133,7 @@
           }
         ],
         "path" : "Task.code",
-        "short" : "(QI-Core) Task Type",
+        "short" : "(QI) Task Type",
         "min" : 1,
         "max" : "1",
         "binding" : {


### PR DESCRIPTION
QI-Core Task - change KeyElement extension to add (QI) in the Description and Constraints table rather than (QI-Core)

QA result:
![{ECA43649-9C61-417B-BDEA-BC3BDBD6D0CD}](https://github.com/user-attachments/assets/1b902d6f-1f85-4c76-8d2b-7a8752adb9c4)
