### PR TITLE
FHIR-47748

### DIFF
--- a/input/intro-notes/StructureDefinition-qicore-imagingstudy-intro.xml
+++ b/input/intro-notes/StructureDefinition-qicore-imagingstudy-intro.xml
@@ -9,7 +9,7 @@
 <li>procedureReference: (QI) The performed Procedure reference</li>
 </ul>
 
-<b>Primary code path:</b> procedure
+<b>Primary code path:</b> <a href='StructureDefinition-qicore-imagingstudy-definitions.html#ImagingStudy.procedureCode'>procedureCode</a>
 <br></br>
 (PCPath) This element is the primary code path for this resource <a href='https://cql.hl7.org/02-authorsguide.html#filtering-with-terminology'>CQL Retrieve</a>
 <br></br>

--- a/input/profiles/StructureDefinition-qicore-imagingstudy.json
+++ b/input/profiles/StructureDefinition-qicore-imagingstudy.json
@@ -4,7 +4,7 @@
   "extension" : [
     {
       "url" : "http://hl7.org/fhir/StructureDefinition/cqf-modelInfo-primaryCodePath",
-      "valueString": "procedure"
+      "valueString": "procedureCode"
     },
     {
       "url" : "http://hl7.org/fhir/StructureDefinition/cqf-modelInfo-isIncluded",


### PR DESCRIPTION
Change primary code path for Imaging Study profile to [procedureCode](https://build.fhir.org/ig/HL7/fhir-qi-core/StructureDefinition-qicore-imagingstudy-definitions.html#ImagingStudy.procedureCode)

QA result: The warning has nothing to do with the current modification and will be suppressed for qi-core
![image](https://github.com/user-attachments/assets/42dae652-d552-4e21-b368-1e5f1ff5dfdb)
