### PR TITLE
FHIR-47750

### DIFF
--- a/input/profiles/StructureDefinition-qicore-nutritionorder.json
+++ b/input/profiles/StructureDefinition-qicore-nutritionorder.json
@@ -59,6 +59,12 @@
     },
     {
         "id" : "NutritionOrder.OralDiet.type",
+        "extension" : [
+          {
+          "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
+          "valueBoolean" : true
+           }
+         ],    
         "path" : "NutritionOrder.OralDiet.type",
         "short" : "(QI) Oral diet components",
         "min" : 0,

--- a/input/profiles/StructureDefinition-qicore-nutritionorder.json
+++ b/input/profiles/StructureDefinition-qicore-nutritionorder.json
@@ -3,6 +3,10 @@
   "id" : "qicore-nutritionorder",
   "extension" : [
     {
+      "url" : "http://hl7.org/fhir/StructureDefinition/cqf-modelInfo-primaryCodePath",
+      "valueString": "type"
+    },
+    {
       "url" : "http://hl7.org/fhir/StructureDefinition/cqf-modelInfo-isIncluded",
       "valueBoolean": true
     },
@@ -54,13 +58,25 @@
       "mustSupport" : false
     },
     {
+        "id" : "NutritionOrder.OralDiet.type",
+        "path" : "NutritionOrder.OralDiet.type",
+        "short" : "(QI) Oral diet components",
+        "min" : 0,
+        "max" : "1",
+        "type" : [{
+          "code" : "Reference",
+          "targetProfile" : ["http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-location"]
+        }]
+        
+    },
+    {
       "id" : "NutritionOrder.patient",
       "extension" : [
         {
           "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
           "valueBoolean" : true
         }
-      ],
+      ],    
       "path" : "NutritionOrder.patient",
       "short" : "(QI) The person who requires the diet, formula or nutritional supplement",
       "definition" : "The person (patient) who needs the nutrition order for an oral diet, nutritional supplement and/or enteral or formula feeding.",


### PR DESCRIPTION
Primary Code path missing on NutritionOrder and QuestionnaireResponse clinical resource types
No code path for QuestionnaireResponse specified

https://jira.hl7.org/browse/FHIR-47750
![830BE9D9-EF13-4F7D-9482-4111AF6C6A9F_4_5005_c](https://github.com/user-attachments/assets/bb36bc58-e0a3-42b5-b47f-a5c52348f024)
Clean QA