### PR TITLE
Fhir 47821

### DIFF
--- a/input/pages/changes.md
+++ b/input/pages/changes.md
@@ -11,6 +11,7 @@ This page lists the change history for each version of QI-Core.
 1. QDM-to-QICore Mapping change Average Blood Pressure to PhysicalExam rather than AssessmentPerformed ([FHIR-46662](https://jira.hl7.org/browse/FHIR-46662)) Applied ([here](qdm-to-qicore.html))
 1. Add hyperlink to Using CQL with FHIR IG ([FHIR-47411](https://jira.hl7.org/browse/FHIR-47411)) Applied ([here](modelinfo.html))
 1. 13.12.1 Resource Profile: QICore wording changes  ([FHIR-47540](https://jira.hl7.org/browse/FHIR-47540)) Applied ([here](StrucutreDefinition-qicore-condition-encounter-diagnosis.html)) 
+1. QI flag not applied consistently for Claim and ClaimResponse profiles ([FHIR-47821](https://jira.hl7.org/browse/FHIR-47821)) Applied ([here](StructureDefinition-qicore-claim.html))
 
 ### STU7-ballot (7.0.0)
 

--- a/input/profiles/StructureDefinition-qicore-claim.json
+++ b/input/profiles/StructureDefinition-qicore-claim.json
@@ -74,21 +74,27 @@
       {
         "id" : "Claim.status",
         "path" : "Claim.status",
-        "short" : "active",
+        "short" : "(QI) active",
         "definition" : "The status of the resource instance.",
         "min" : 1,
         "max" : "1",
-        "extension" : [
+        "extension": [
           {
-            "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
-            "valueBoolean" : true
+            "url": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
+            "valueBoolean": true
           }
-        ]
+        ],
+        "type": [
+          {
+            "code": "code"
+          }
+        ],
+        "fixedCode": "active"
       },
       {
         "id" : "Claim.type",
         "path" : "Claim.type",
-        "short" : "category | discipline",
+        "short" : "(QI) category | discipline",
         "min" : 1,
         "max" : "1",
         "extension" : [
@@ -101,7 +107,7 @@
       {
         "id" : "Claim.use",
         "path" : "Claim.use",
-        "short" : "claim | preauthorization | predetermination",
+        "short" : "(QI) claim | preauthorization | predetermination",
         "min" : 1,
         "max" : "1",
         "extension" : [

--- a/input/profiles/StructureDefinition-qicore-claim.json
+++ b/input/profiles/StructureDefinition-qicore-claim.json
@@ -77,21 +77,39 @@
         "short" : "active",
         "definition" : "The status of the resource instance.",
         "min" : 1,
-        "max" : "1"
+        "max" : "1",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
+            "valueBoolean" : true
+          }
+        ]
       },
       {
         "id" : "Claim.type",
         "path" : "Claim.type",
         "short" : "category | discipline",
         "min" : 1,
-        "max" : "1"
+        "max" : "1",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
+            "valueBoolean" : true
+          }
+        ]
       },
       {
         "id" : "Claim.use",
         "path" : "Claim.use",
         "short" : "claim | preauthorization | predetermination",
         "min" : 1,
-        "max" : "1"
+        "max" : "1",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-keyelement",
+            "valueBoolean" : true
+          }
+        ]
       },
       {
         "id" : "Claim.patient",

--- a/input/profiles/StructureDefinition-qicore-claim.json
+++ b/input/profiles/StructureDefinition-qicore-claim.json
@@ -72,6 +72,28 @@
         "mustSupport" : false
       },
       {
+        "id" : "Claim.status",
+        "path" : "Claim.status",
+        "short" : "active",
+        "definition" : "The status of the resource instance.",
+        "min" : 1,
+        "max" : "1"
+      },
+      {
+        "id" : "Claim.type",
+        "path" : "Claim.type",
+        "short" : "category | discipline",
+        "min" : 1,
+        "max" : "1"
+      },
+      {
+        "id" : "Claim.use",
+        "path" : "Claim.use",
+        "short" : "claim | preauthorization | predetermination",
+        "min" : 1,
+        "max" : "1"
+      },
+      {
         "id" : "Claim.patient",
         "extension" : [
           {


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-47821

Claim type and claim use bindings are coming up with errors as they seem to be outdated. This PR is everything else in the tracker without these bindings. 

![9DB99226-B02C-4100-81B5-7D7DC9A69C23_1_105_c](https://github.com/user-attachments/assets/4f73e159-0e4d-48b2-8906-9056c5b3fc04)
No qa errors without these bindings. 

With bindings
![C8BC836C-270D-455A-9AA0-E3CD1F72903B_1_105_c](https://github.com/user-attachments/assets/f4fe1b3a-2a13-4357-9ecd-693f7e214709)
