### PR TITLE
dd-QA-2 More QA edits

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -118,3 +118,24 @@ This element does not match any known slice defined in the profile http://hl7.or
 # The following are suppressed as they are the result of issues within the associated base definition, outside of this IG.
 The slice 'CLIA' on path 'Organization.identifier' is not marked as 'must-support' which is not consistent with the element that defines the slicing, where 'must-support' is true
 The slice 'NAIC' on path 'Organization.identifier' is not marked as 'must-support' which is not consistent with the element that defines the slicing, where 'must-support' is true
+
+# The following information messages are suppressed 
+Pinned the version of http://hl7.org/fhir/StructureDefinition/codeOptions to 7.0.0 from choices of 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0), 7.0.0 (hl7.fhir.us.qicore#7.0.0)
+Pinned the version of http://hl7.org/fhir/StructureDefinition/questionnaireresponse-signature to 5.2.0 from choices of 1.0.0 (hl7.fhir.uv.extensions.r4#1.0.0), 4.0.1 (hl7.fhir.r4.core#4.0.1), 5.1.0 (hl7.fhir.uv.extensions.r4#5.1.0), 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0)
+Pinned the version of http://hl7.org/fhir/StructureDefinition/questionnaireresponse-completionMode to 5.2.0 from choices of 1.0.0 (hl7.fhir.uv.extensions.r4#1.0.0), 4.0.1 (hl7.fhir.r4.core#4.0.1), 5.1.0 (hl7.fhir.uv.extensions.r4#5.1.0), 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0)
+Pinned the version of http://hl7.org/fhir/StructureDefinition/display to 5.2.0 from choices of 1.0.0 (hl7.fhir.uv.extensions.r4#1.0.0), 4.0.1 (hl7.fhir.r4.core#4.0.1), 5.1.0 (hl7.fhir.uv.extensions.r4#5.1.0), 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0)
+Pinned the version of http://hl7.org/fhir/StructureDefinition/questionnaireresponse-signature to 5.2.0 from choices of 1.0.0 (hl7.fhir.uv.extensions.r4#1.0.0), 4.0.1 (hl7.fhir.r4.core#4.0.1), 5.1.0 (hl7.fhir.uv.extensions.r4#5.1.0), 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0)
+Pinned the version of http://hl7.org/fhir/StructureDefinition/ordinalValue to 5.2.0 from choices of 4.0.1 (hl7.fhir.r4.core#4.0.1), 5.2.0 (hl7.fhir.uv.extensions.r4#5.2.0)
+
+# The following information message is suppressed as it merely suggests a review of values in a ValueSet which may or may not occur in the future
+The resource status 'draft' and the standards status 'trial-use' may not be consistent and should be reviewed
+
+# Suppressed messages warning about an placeholder example oid by convention
+URL value 'urn:oid:1.2.36.146.595.217.0.1' does not resolve
+
+# The following information message is suppressed as it refers to an issue in a base resource defined elsewhere
+The extension http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet|5.2.0 is deprecated
+
+# The following information messages in Questionnaire Response are suppressed as they refer to elements in the snapshot base resource
+The extension http://hl7.org/fhir/StructureDefinition/ordinalValue|5.2.0 is deprecated with the note Replaced by [[[http://hl7.org/fhir/StructureDefinition/itemWeight]]]
+The extension http://hl7.org/fhir/StructureDefinition/regex|5.2.0 is deprecated with the note This was deprecated in favor of using a constraint on the element using FHIRPath, since constraints allow for the provision of a human readable message associated with the regex

--- a/input/profiles/StructureDefinition-qicore-allergyintolerance.json
+++ b/input/profiles/StructureDefinition-qicore-allergyintolerance.json
@@ -65,23 +65,6 @@
       },
       
       {
-        "id": "AllergyIntolerance.extension:resolutionAge",
-        "path": "AllergyIntolerance.extension",
-        "sliceName": "resolutionAge",
-        "definition": "The estimated patient age at which the allergy or intolerance resolved. Should be specified only if the status is resolved.",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/StructureDefinition/allergyintolerance-resolutionAge|5.2.0-ballot"
-            ]
-          }
-        ],
-        "mustSupport": false
-      },
-      {
         "id" : "AllergyIntolerance.clinicalStatus",
         "extension": [
           {

--- a/input/resources/questionnaireresponse-example.xml
+++ b/input/resources/questionnaireresponse-example.xml
@@ -10,7 +10,7 @@
   <subject>
     <reference value="Patient/example"/>
   </subject>
-  <authored value="2022-07-31T22:14:07.387Z"/>
+  <authored value="2020-07-31T22:14:07.387Z"/>
   <author>
     <reference value="Practitioner/example"/>
   </author>


### PR DESCRIPTION
- Suppressed all pinned info messages
- Suppressed a deprecation message in AdverseEvent as it refers to an issue in the base resource
- Removed AllergyIntolerance.extension:resolutionAge as it is deprecated and should no longer be used
- Suppressed info messages recommending review of status values in a resource outside the IG
- In questionnaire response example, adjusted authored date to comply with questionnaire permitted period
- In questionnaire response profile, suppressed 'deprecated' messages referencing elements in the base profile